### PR TITLE
Flux Standard Action: meta for redraw

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,48 +1,50 @@
+import _ from 'lodash/fp';
+
 class _Provider {
-  init(store, mithril, Component) {
-    this.store = store;
-    this.mithril = mithril;
-    const comp = typeof Component === 'function' ? new Component() : Component;
-    return comp;
-  }
+	init( store, mithril, Component ) {
+		this.store = store; 		//eslint-disable-line
+		this.mithril = mithril; //eslint-disable-line
+		const comp = _.isFunction( Component ) ? new Component() : Component;
+		return comp;
+	}
 }
 
 export const Provider = new _Provider;
 
+function actionMapper( actions, dispatch ) {
 
-function wrapView(comp, actionMap) {
-  const origView = comp.view;
-  comp.view = (ctrl, ...args) => {
-    let nc = {...ctrl, ...actionMap};
-    return origView(nc, ...args);
-  };
+	if ( _.isFunction( actions ) ) {
+		return actions( dispatch );
+	} else if ( _.isObject( actions ) ) {
+		return _.flow(
+			_.keys,
+			_.filter( _.isFunction ),
+			_.map( mappedAction => ( ...factoryArgs ) => ( ...args ) => dispatch( mappedAction( ...factoryArgs, ...args ) ) )
+		)( actions );
+	}
 }
 
-export const connect = (selector, actions) => (Component) => {
-  return {
-    view (controller, props, children) {
-      const {dispatch, getState} = Provider.store;
-      let actionMap = {};
-      if (typeof actions === 'function') {
-        actionMap = actions(dispatch);
-      } else if (typeof actions === 'object') {;
-        for (let k of Object.keys(actions)) {
-          if (typeof actions[k] === 'function') {
-            actionMap[k] = (...factoryArgs) => (...args) => dispatch(actions[k](...factoryArgs, ...args))
-          }
-        }
-      }
-      const state = selector(getState());
-      const comp = typeof Component === 'function' ? new Component() : Component;
-      wrapView(comp, actionMap);
-      return Provider.mithril.component(comp, {dispatch, ...state, ...actionMap}, children);
-    }
-  };
+export const connect = ( selector, actions ) => ( Component ) => {
+	return {
+		view( controller, props, children ) {
+			const { dispatch, getState } = Provider.store;
+
+			const state = selector( getState() );
+			const comp = _.isFunction( Component ) ? new Component() : Component;
+			const actionMap = actionMapper( actions, dispatch );
+			const origView = comp.view;
+			const c = {
+				...comp,
+				view: ( ctrl, ...args ) => origView( { ...ctrl, ...actionMap }, ...args )
+			};
+			return Provider.mithril.component( c, { dispatch, ...state, ...actionMap }, children );
+		}
+	};
 };
 
-export const redrawMiddleware = (store) => (next) => (action) => {
-  next(action);
-  if (action.meta.redraw && Provider.mithril) {
-    Provider.mithril.redraw();
-  }
+export const redrawMiddleware = () => ( next ) => ( action ) => {
+	next( action );
+	if ( action.meta.redraw && Provider.mithril ) {
+		Provider.mithril.redraw();
+	}
 };

--- a/index.js
+++ b/index.js
@@ -25,9 +25,8 @@ export const connect = (selector, actions) => (Component) => {
       let actionMap = {};
       if (typeof actions === 'function') {
         actionMap = actions(dispatch);
-      } else if (typeof actions === 'object') {
-        const actionKeys = Object.keys(actions);
-        for (let k of actionKeys) {
+      } else if (typeof actions === 'object') {;
+        for (let k of Object.keys(actions)) {
           if (typeof actions[k] === 'function') {
             actionMap[k] = (...factoryArgs) => (...args) => dispatch(actions[k](...factoryArgs, ...args))
           }
@@ -43,7 +42,7 @@ export const connect = (selector, actions) => (Component) => {
 
 export const redrawMiddleware = (store) => (next) => (action) => {
   next(action);
-  if (action.redraw && Provider.mithril) {
+  if (action.meta.redraw && Provider.mithril) {
     Provider.mithril.redraw();
   }
 };

--- a/package.json
+++ b/package.json
@@ -26,14 +26,17 @@
     "mithril": "^0.2.0"
   },
   "devDependencies": {
-    "babel": "^6.3.26",
-    "babel-plugin-transform-function-bind": "^6.3.13",
-    "babel-plugin-transform-object-rest-spread": "^6.3.13",
-    "babel-preset-es2015": "^6.3.13",
-    "gulp": "^3.9.0",
-    "gulp-babel": "^6.1.1",
+    "babel": "^6.5.2",
+    "babel-plugin-transform-function-bind": "^6.5.2",
+    "babel-plugin-transform-object-rest-spread": "^6.6.5",
+    "babel-preset-es2015": "^6.6.0",
+    "gulp": "^3.9.1",
+    "gulp-babel": "^6.1.2",
     "gulp-concat": "^2.6.0",
     "gulp-sourcemaps": "^1.6.0",
     "gulp-umd": "^0.2.0"
+  },
+  "dependencies": {
+    "lodash": "^4.10.0"
   }
 }


### PR DESCRIPTION
Hi @colinbate,

Thank you for this project and the documentation. It saved me quite some time. 

This is more a question than anything else, but after reading [Flux Standard Action](https://github.com/acdlite/flux-standard-action#actions)

> An action MUST NOT include properties other than `type`, `payload`, and `error`, and `meta`.

So I added the `redraw` in `meta`.
What do you think?
