### PR TITLE
fix action mapper

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,9 +26,11 @@ export const connect = (selector, actions) => (Component) => ({
       actionMap = actions(dispatch);
     } else if (typeof actions === 'object') {
       const actionKeys = Object.keys(actions);
-      actionMap = actionKeys
-        .filter(k => typeof actions[k] === 'function')
-        .map(k => (...factoryArgs) => (...args) => dispatch(actions[k](...factoryArgs, ...args)));
+      for (let k of actionKeys) {
+        if (typeof actions[k] === 'function') {
+          actionMap[k] = (...factoryArgs) => (...args) => dispatch(actions[k](...factoryArgs, ...args));
+        }
+      }
     }
     const state = selector(getState());
     const comp = typeof Component === 'function' ? new Component() : Component;


### PR DESCRIPTION
Sorry for inducing this error in #1.
The second commit was not meant to be published, I was just experimenting. I apologize.

With chained action it returns an array, not an object!

![mithril-redux-error](https://cloud.githubusercontent.com/assets/5487021/14520974/799a64ee-0227-11e6-8d4d-12c520e87f77.PNG)

That removes the name of the action mapper in the controller. 

By reverting to the previous code, it worked again.

![mithril-redux-fixed](https://cloud.githubusercontent.com/assets/5487021/14520910/20cbbe1c-0227-11e6-90ae-18f307e06164.PNG)
