### PR TITLE
fix passing properties to component

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ export const connect = (selector, actions) => (Component) => ({
     const state = selector(getState());
     const comp = typeof Component === 'function' ? new Component() : Component;
     wrapView(comp, actionMap);
-    return Provider.mithril.component(comp, {dispatch, ...state, ...actionMap}, children);
+    return Provider.mithril.component(comp, {dispatch, ...state, ...actionMap, ...props}, children);
   }
 });
 


### PR DESCRIPTION
Properties are ignored when initializing a component:

``` javascript
m( myComponent, { opt1: 'JSONOutput', opt2: [ 1, 2, 3 ] } ); // opt1 and opt2 are ignored.

```
